### PR TITLE
change validation for Post description

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,7 +1,7 @@
 class Task < ActiveRecord::Base
   validates_presence_of :name, :description
   validates_length_of :name, minimum: 5, too_short: 'Please enter a longer name'
-  validates_length_of :name, minimum: 5, too_short: 'Your description must be at least 100 words'
+  validates_length_of :description, minimum: 100, too_short: 'Your description must be at least 100 characters'
 
   has_many :steps, dependent: :destroy
   accepts_nested_attributes_for :steps,


### PR DESCRIPTION
I think you wanted to validated the description length, not the name.  I changed the alert to 100 characters instead of words, since I don't know how to validate by word count.
